### PR TITLE
Filter bypass suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,15 @@
       font-size: 16px;
     }
 
+    #suggestions {
+      margin-top: 15px;
+      padding: 10px;
+      min-height: 120px;
+      border: 1px solid #ccc;
+      white-space: pre-wrap;
+      font-size: 16px;
+    }
+
     mark {
       background: yellow;
       color: black;
@@ -37,6 +46,8 @@
   <h1>UmaFlagger</h1>version 1.0</br>
   <textarea id="input" placeholder="Type text here..."></textarea>
   <div id="output"></div>
+  <h2>Suggestions to bypass filter</h2>
+  <div id="suggestions"></div>
 
   <script src="script.js"></script></br>
   Vibe-coded Scunthorpe problem finder for Umamusume.

--- a/script.js
+++ b/script.js
@@ -4,6 +4,20 @@ const bannedWords = ["inko", "sag", "kill", "butt", "sex", "tit", "fuk", "ifica"
 
 const input = document.getElementById("input");
 const output = document.getElementById("output");
+// New element for suggestions
+let suggestionsDiv = document.getElementById("suggestions");
+
+const replace_map = {
+  a: ["4"],
+  e: ["3"],
+  i: ["1"],
+  o: ["0"],
+  s: ["5"],
+  t: ["7"],
+  g: ["9"],
+  b: ["8"],
+  l: ["1"]
+};
 
 function findOffenses(text, banned) {
   const offenses = [];
@@ -83,8 +97,36 @@ function escapeHTML(str) {
   }[m]));
 }
 
+function bypassFilter(text, offenses) {
+  let replacedText = [];
+  if (offenses.length > 0) {
+    for (let i = 0; i < offenses.length; i++) {
+      const [start, end] = offenses[i];
+      const word = text.slice(start, end + 1).trim();
+      let modifiedWord = null;
+      for (let j = 0; j < word.length; j++) {
+        const ch = word[j].toLowerCase();
+        if (replace_map[ch]) {
+          const replacements = replace_map[ch][0];
+          modifiedWord = word.slice(0, j) + replacements + word.slice(j + 1);
+          break;
+        }
+      }
+      if (modifiedWord) {
+        replacedText.push(`"${word}" → "${modifiedWord}"`);
+      }
+    }
+    if (replacedText.length > 0) {
+      suggestionsDiv.innerHTML = "<strong>Bypass suggestions:</strong><br>" + replacedText.join("<br>");
+    } else {
+      suggestionsDiv.innerHTML = "No bypass suggestions available.";
+    }
+  }
+}
+
 input.addEventListener("input", () => {
   const text = input.value;
   const offenses = findOffenses(text, bannedWords);
   output.innerHTML = highlight(text, offenses);
+  bypassFilter(text, offenses);
 });


### PR DESCRIPTION
Hello! I messaged you on Reddit earlier today about adding to the website. I didn't have time to do much, but I did do a few things

- Fixed a bug where words like classic or supergeiboy were not caught. Did this by deleting the function that checks if a space is present before adding to the offenses list
- Started the "suggested bypass to the filter" logic. Basically if you type in a sentence it offers replacement words to bypass the filter (inko is replaced by 1nko). It works fine as is, but it only replaces the first letter of a word, and it has no answer for if a word doesn't have a replaceable letter (like 'fuk'). All fixable, but I'll do it later. 
- Added more punctuation that the game filter would catch but yours does not ('.', '|', '@', etc). Just covering more bases